### PR TITLE
Add auto-assign issues with take comment

### DIFF
--- a/.github/workflows/auto_assign_issues.yml
+++ b/.github/workflows/auto_assign_issues.yml
@@ -1,0 +1,40 @@
+# This workflow has been inspired by https://github.com/MrPowers/quinn/blob/main/.github/workflows/assign-on-comment.yml
+
+name: Auto Assign Issues On Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    if: (!github.event.issue.pull_request) && github.event.comment.body == 'take'
+    concurrency:
+      # Only run one a time per user
+      group: ${{ github.actor }}-auto-assign-issue
+    steps:
+      - name: Check if issue can be assigned
+        id: check-assignee
+        run: |
+          # Check if the user is already assigned to the issue
+          RESPONSE=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -LI https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees/${{ github.event.comment.user.login }} -o /dev/null -w '%{http_code}' -s)
+          echo "HTTP_CODE=$RESPONSE" >> $GITHUB_ENV
+
+      - name: Assign issue to commenter
+        if: env.HTTP_CODE == '204'
+        run: |
+          # Assign the issue to the user who commented 'take'
+          echo "Assigning issue #${{ github.event.issue.number }} to @${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log failure to assign
+        if: env.HTTP_CODE != '204'
+        run: |
+          # Log the failure to assign the issue
+          echo "Issue #${{ github.event.issue.number }} cannot be assigned to @${{ github.event.comment.user.login }}. HTTP response code: ${{ env.HTTP_CODE }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ We are excited to work with the open source communities in the many years to com
 - Specifically, if the goal is to add a new extension, please read the extension policy.
 - Small patches and bug fixes don't need prior communication. If you have identified a bug and have ways to solve it, please create an [issue](https://github.com/unitycatalog/unitycatalog/issues) or create a [pull request](https://github.com/unitycatalog/unitycatalog/pulls).
 
+# Auto-Assigning Issues
+We have implemented a feature that allows users to comment "**take**" on an issue to be auto-assigned the issue without having to depend on or wait for the maintainers to assign the issue before working on it.
 
 # Coding style
 We generally follow the [Apache Spark Scala Style Guide](https://spark.apache.org/contributing.html).


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
This PR is related to #121

* Add auto-assign functionality for issues based on comments
  - **CONTRIBUTING.md**: Add a section about auto-assigning issues based on comments. Mention that users can comment "take" on an issue to be auto-assigned the issue.
  - **.github/workflows/auto_assign_issues.yml**: Create a new workflow file named `auto_assign_issues.yml`. Add a trigger for issue comments. Check if the comment is "take". Assign the issue to the user who commented "take". Check if the user is already assigned to the issue and log a message if the issue cannot be assigned.

**Further comments**
* This workflow is inspired by https://github.com/MrPowers/quinn/blob/main/.github/workflows/assign-on-comment.yml and the same has already been mentioned in the workflow file.
* I have updated the CONTRIBUTING.md (docs) file as well to reflect this functionality is available to the users.