### PR TITLE
Rollback changes made on auto-assign workflow related to GITHUB_TOKEN 

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -21,7 +21,7 @@ jobs:
         id: check-assignee
         run: |
           # Check if the user is already assigned to the issue
-          RESPONSE=$(curl -LI https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees/${{ github.event.comment.user.login }} -o /dev/null -w '%{http_code}' -s)
+          RESPONSE=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -LI https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees/${{ github.event.comment.user.login }} -o /dev/null -w '%{http_code}' -s)
           echo "HTTP_CODE=$RESPONSE" >> $GITHUB_ENV
 
       - name: Assign issue to commenter
@@ -29,7 +29,7 @@ jobs:
         run: |
           # Assign the issue to the user who commented 'take'
           echo "Assigning issue #${{ github.event.issue.number }} to @${{ github.event.comment.user.login }}"
-          curl -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

* Rollback and introduce the GitHub token authorisation for the workflow

  - [As per this comment](https://github.com/unitycatalog/unitycatalog/pull/188#discussion_r1673479639), the GITHUB_TOKEN part was removed to check if the workflow still runs that action and assigns the issue automatically. However, upon checking, it didn't. Hence, rolled back on that change.